### PR TITLE
indicatorYOffset inititialized to 0.0f

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -153,7 +153,7 @@
 }
 
 - (CGRect)frameForSelectionIndicator {
-    CGFloat indicatorYOffset;
+    CGFloat indicatorYOffset = 0.0f;
         
     if (self.selectionLocation == HMSegmentedControlSelectionLocationDown)
         indicatorYOffset = self.bounds.size.height - self.selectionIndicatorHeight;


### PR DESCRIPTION
I ran into a very strange case where if I used this control in an archived ipa sent over testflight, the indicatorYOffset when using HMSegmentedControlSelectionLocationUp would be below the frame where it was supposed to be. (Strangely enough it worked fine when attached and debugging with XCode)

![photo 1 ](https://f.cloud.github.com/assets/201957/279350/23e1cf28-911f-11e2-9397-cedce07692a6.JPG)

Once I set this to 0 by default I no longer had the issue. I'm assuming it has to do with the fact that inititalized floats may not have to be zero'd or perhaps because I used a xib. Either way, very strange.
