### PR TITLE
Fixes warning when compiling for iOS 7

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -207,8 +207,13 @@
         
         if (self.type == HMSegmentedControlTypeText) {
             for (NSString *titleString in self.sectionTitles) {
+#ifdef __IPHONE_7_0
+                CGFloat stringWidth = [titleString sizeWithAttributes:@{NSFontAttributeName: self.font}].width + self.segmentEdgeInset.left + self.segmentEdgeInset.right;
+                self.segmentWidth = MAX(stringWidth, self.segmentWidth);
+#else
                 CGFloat stringWidth = [titleString sizeWithFont:self.font].width + self.segmentEdgeInset.left + self.segmentEdgeInset.right;
                 self.segmentWidth = MAX(stringWidth, self.segmentWidth);
+#endif
             }
             self.bounds = CGRectMake(0, 0, self.segmentWidth * self.sectionTitles.count, self.height);
         } else if (self.type == HMSegmentedControlTypeImages) {


### PR DESCRIPTION
Replaces deprecated NSString class method sizeWithFont: with sizeWithAttributes:
