### PR TITLE
Add support for auto-layout constraints

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -136,6 +136,12 @@ typedef enum {
     self.contentMode = UIViewContentModeRedraw;
 }
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    
+    [self updateSegmentsRects];
+}
+
 - (void)setFrame:(CGRect)frame {
     [super setFrame:frame];
     
@@ -145,18 +151,18 @@ typedef enum {
 - (void)setSectionTitles:(NSArray *)sectionTitles {
     _sectionTitles = sectionTitles;
     
-    [self updateSegmentsRects];
+    [self setNeedsLayout];
 }
 
 - (void)setSectionImages:(NSArray *)sectionImages {
     _sectionImages = sectionImages;
     
-    [self updateSegmentsRects];
+    [self setNeedsLayout];
 }
 
 #pragma mark - Drawing
 
-- (void)drawRect:(CGRect)rect {    
+- (void)drawRect:(CGRect)rect {
     [self.backgroundColor setFill];
     UIRectFill([self bounds]);
 


### PR DESCRIPTION
Following discussion in #22 I took the liberty to make some changes which fixes the issue where the frame of the scroll view would not get adjusted when the control's frame is managed through layout constraints.
