### PR TITLE
Add support for custom box layer opacity.

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -87,6 +87,13 @@ typedef enum {
 @property (nonatomic, strong) UIColor *selectionIndicatorColor;
 
 /*
+ Opacity for the seletion inficator box.
+ 
+ Default is 0.2
+ */
+@property (nonatomic) CGFloat selectionIndicatorBoxOpacity;
+
+/*
  Specifies the style of the control
  
  Default is `HMSegmentedControlTypeText`

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -155,8 +155,10 @@
     
     self.selectionIndicatorStripLayer = [CALayer layer];
     
+    self.selectionIndicatorBoxOpacity = 0.2;
+    
     self.selectionIndicatorBoxLayer = [CALayer layer];
-    self.selectionIndicatorBoxLayer.opacity = 0.2;
+    self.selectionIndicatorBoxLayer.opacity = self.selectionIndicatorBoxOpacity;
     self.selectionIndicatorBoxLayer.borderWidth = 1.0f;
     
     self.contentMode = UIViewContentModeRedraw;
@@ -192,6 +194,13 @@
 	if (selectionIndicatorLocation == HMSegmentedControlSelectionIndicatorLocationNone) {
 		self.selectionIndicatorHeight = 0.0f;
 	}
+}
+
+- (void)setSelectionIndicatorBoxOpacity:(CGFloat)selectionIndicatorBoxOpacity
+{
+    _selectionIndicatorBoxOpacity = selectionIndicatorBoxOpacity;
+    
+    self.selectionIndicatorBoxLayer.opacity = _selectionIndicatorBoxOpacity;
 }
 
 #pragma mark - Drawing

--- a/HMSegmentedControlExample/HMSegmentedControlExample/ViewController.m
+++ b/HMSegmentedControlExample/HMSegmentedControlExample/ViewController.m
@@ -70,10 +70,11 @@
     segmentedControl3.backgroundColor = [UIColor colorWithRed:0.1 green:0.4 blue:0.8 alpha:1];
     segmentedControl3.textColor = [UIColor whiteColor];
     segmentedControl3.selectedTextColor = [UIColor whiteColor];
-    segmentedControl3.selectionIndicatorColor = [UIColor colorWithRed:0.5 green:0.8 blue:1 alpha:1];
+    segmentedControl3.selectionIndicatorColor = [UIColor blackColor];
+    segmentedControl3.selectionIndicatorBoxOpacity = 1.0;
     segmentedControl3.selectionStyle = HMSegmentedControlSelectionStyleBox;
     segmentedControl3.selectedSegmentIndex = HMSegmentedControlNoSegment;
-    segmentedControl3.selectionIndicatorLocation = HMSegmentedControlSelectionIndicatorLocationDown;
+    segmentedControl3.selectionIndicatorLocation = HMSegmentedControlSelectionIndicatorLocationNone;
     segmentedControl3.shouldAnimateUserSelection = NO;
     segmentedControl3.tag = 2;
     [self.view addSubview:segmentedControl3];


### PR DESCRIPTION
Hi,

I needed to specify a custom opacity color for the selected segment box, then I added a property for doing so. The default behavior is preserved, unless you set a new 'selectionIndicatorBoxOpacity' value.

Thanks,
Alexandre
