### PR TITLE
made scrolling to the selected segment respect the animated flag

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -640,7 +640,7 @@
     }
 }
 
-- (void)scrollToSelectedSegmentIndex {
+- (void)scrollToSelectedSegmentIndex:(BOOL)animated {
     CGRect rectForSelectedIndex;
     CGFloat selectedSegmentOffset = 0;
     if (self.segmentWidthStyle == HMSegmentedControlSegmentWidthStyleFixed) {
@@ -672,7 +672,7 @@
     CGRect rectToScrollTo = rectForSelectedIndex;
     rectToScrollTo.origin.x -= selectedSegmentOffset;
     rectToScrollTo.size.width += selectedSegmentOffset * 2;
-    [self.scrollView scrollRectToVisible:rectToScrollTo animated:YES];
+    [self.scrollView scrollRectToVisible:rectToScrollTo animated:animated];
 }
 
 #pragma mark - Index change
@@ -694,7 +694,7 @@
         [self.selectionIndicatorStripLayer removeFromSuperlayer];
         [self.selectionIndicatorBoxLayer removeFromSuperlayer];
     } else {
-        [self scrollToSelectedSegmentIndex];
+        [self scrollToSelectedSegmentIndex:animated];
         
         if (animated) {
             // If the selected segment layer is not added to the super layer, that means no


### PR DESCRIPTION
Hey,

Currently when you pass NO as animated flag to

- (void)setSelectedSegmentIndex:(NSUInteger)index animated:(BOOL)animated;

the scrolling is still animated. I suggest to make scrolling to respect the animated flag.