### PR TITLE
Added fix to avoid blurry labels

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -251,6 +251,9 @@
                 rect = CGRectMake(xOffset, y, [[self.segmentWidthsArray objectAtIndex:idx] floatValue], stringHeight);
             }
             
+            // Fix rect position/size to avoid blurry labels
+            rect = CGRectMake(ceilf(rect.origin.x), ceilf(rect.origin.y), ceilf(rect.size.width), ceilf(rect.size.height));
+            
             CATextLayer *titleLayer = [CATextLayer layer];
             titleLayer.frame = rect;
             titleLayer.font = (__bridge CFTypeRef)(self.font.fontName);


### PR DESCRIPTION
Current implementation works fine, but all labels are a bit blurry. You can see that in this screenshot

![before](https://cloud.githubusercontent.com/assets/66432/4164509/c8584282-34f5-11e4-99ac-45f122857295.png)

I created a simple fix to avoid blurry labels. Compare first screenshot with second and you will see the difference!

![after](https://cloud.githubusercontent.com/assets/66432/4164511/d25c93e6-34f5-11e4-985d-a772637bc854.png)

Thanks and keep up the good work!