### PR TITLE
Advanced styling support with text attributes for kerning, shadow, etc.

### DIFF
--- a/HMSegmentedControl.podspec
+++ b/HMSegmentedControl.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }
   s.author       = { "Hesham Abd-Elmegid" => "hesham.abdelmegid@gmail.com" }
   s.source       = { :git => "https://github.com/HeshamMegid/HMSegmentedControl.git", :tag => "v1.3.0" }
-  s.platform     = :ios, '5.0'
+  s.platform     = :ios, '7.0'
   s.requires_arc = true
   s.source_files = 'HMSegmentedControl/*.{h,m}'
   s.framework  = 'QuartzCore'

--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -52,6 +52,24 @@ typedef enum {
 @property (nonatomic, copy) IndexChangeBlock indexChangeBlock;
 
 /*
+ Text attributes to apply to item title texts.
+ 
+ The eventual text attributes applied to titles are comprised of this dictionary and the values in `font` and
+ `textColor` properties. The attributes specified in this dictionary (if present) take precedence over `font` and 
+ `textColor` properties.
+ */
+@property (nonatomic, strong) NSDictionary *titleTextAttributes;
+
+/*
+ Text attributes to apply to selected item title text.
+ 
+ The eventual text attributes applied to selected title are defined by eventual title text attributes overriden by
+ `selectedTextColor` property value, overriden by the values in this dictionary, so that you only need to specify what
+ sets the selected title apart from a title in the default state.
+ */
+@property (nonatomic, strong) NSDictionary *selectedTitleTextAttributes;
+
+/*
  Font for segments names when segmented control type is `HMSegmentedControlTypeText`
  
  Default is [UIFont fontWithName:@"STHeitiSC-Light" size:18.0f]

--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -8,7 +8,10 @@
 
 #import <UIKit/UIKit.h>
 
+@class HMSegmentedControl;
+
 typedef void (^IndexChangeBlock)(NSInteger index);
+typedef NSAttributedString *(^HMTitleFormatterBlock)(HMSegmentedControl *segmentedControl, NSString *title, BOOL selected);
 
 typedef enum {
     HMSegmentedControlSelectionStyleTextWidthStripe, // Indicator width will only be as big as the text width
@@ -40,6 +43,9 @@ typedef enum {
 
 @interface HMSegmentedControl : UIControl
 
+/* 
+ * Array of `NSString` objects
+ */
 @property (nonatomic, strong) NSArray *sectionTitles;
 @property (nonatomic, strong) NSArray *sectionImages;
 @property (nonatomic, strong) NSArray *sectionSelectedImages;
@@ -50,6 +56,13 @@ typedef enum {
  Alternativly, you could use `addTarget:action:forControlEvents:`
  */
 @property (nonatomic, copy) IndexChangeBlock indexChangeBlock;
+
+/*
+ * This block is used to apply custom text styling to titles when set.
+ *
+ * When this block is provided, no additional styling is applied to the `NSAttributedString` object returned from this block.
+ */
+@property (nonatomic, copy) HMTitleFormatterBlock titleFormatter;
 
 /*
  Text attributes to apply to item title texts.

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -253,8 +253,10 @@
             stringHeight = size.height;
             
             // Text inside the CATextLayer will appear blurry unless the rect values are rounded
-            CGFloat y = roundf(CGRectGetHeight(self.frame) - self.selectionIndicatorHeight)/2 - stringHeight/2 + ((self.selectionIndicatorLocation == HMSegmentedControlSelectionIndicatorLocationUp) ? self.selectionIndicatorHeight : 0);
-            
+            BOOL locationUp = (self.selectionIndicatorLocation == HMSegmentedControlSelectionIndicatorLocationUp);
+            BOOL selectionStyleNotBox = (self.selectionStyle != HMSegmentedControlSelectionStyleBox);
+
+            CGFloat y = roundf((CGRectGetHeight(self.frame) - selectionStyleNotBox * self.selectionIndicatorHeight)/2 - stringHeight/2 + self.selectionIndicatorHeight * locationUp);
             CGRect rect;
             if (self.segmentWidthStyle == HMSegmentedControlSegmentWidthStyleFixed) {
                 rect = CGRectMake((self.segmentWidth * idx) + (self.segmentWidth - stringWidth)/2, y, stringWidth, stringHeight);

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -206,9 +206,12 @@
 - (CGSize)measureTitleAtIndex:(NSUInteger)idx {
     id title = self.sectionTitles[idx];
     CGSize size = CGSizeZero;
-    if ([title isKindOfClass:[NSString class]]) {
-        NSDictionary *titleAttrs = idx == self.selectedSegmentIndex ? [self resultingSelectedTitleTextAttributes] : [self resultingTitleTextAttributes];
+    BOOL selected = idx == self.selectedSegmentIndex;
+    if ([title isKindOfClass:[NSString class]] && self.titleFormatter == nil) {
+        NSDictionary *titleAttrs = selected ? [self resultingSelectedTitleTextAttributes] : [self resultingTitleTextAttributes];
         size = [(NSString *)title sizeWithAttributes:titleAttrs];
+    } else if ([title isKindOfClass:[NSString class]] && self.titleFormatter != nil) {
+        size = [self.titleFormatter(self, title, selected) size];
     } else if ([title isKindOfClass:[NSAttributedString class]]) {
         size = [(NSAttributedString *)title size];
     } else {

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -219,15 +219,13 @@
 }
 
 - (NSAttributedString *)attributedTitleAtIndex:(NSUInteger)idx {
-    id title = self.sectionTitles[idx];
-    if ([title isKindOfClass:[NSString class]]) {
-        NSDictionary *titleAttrs = idx == self.selectedSegmentIndex ? [self resultingSelectedTitleTextAttributes] : [self resultingTitleTextAttributes];
+    NSString *title = self.sectionTitles[idx];
+    BOOL selected = idx == self.selectedSegmentIndex;
+    if (self.titleFormatter == nil) {
+        NSDictionary *titleAttrs = selected ? [self resultingSelectedTitleTextAttributes] : [self resultingTitleTextAttributes];
         return [[NSAttributedString alloc] initWithString:(NSString *)title attributes:titleAttrs];
-    } else if ([title isKindOfClass:[NSAttributedString class]]) {
-        return (NSAttributedString *)title;
     } else {
-        NSAssert(title == nil, @"Unexpected type of segment title: %@", [title class]);
-        return nil;
+        return self.titleFormatter(self, title, selected);
     }
 }
 

--- a/HMSegmentedControlExample/HMSegmentedControlExample.xcodeproj/project.pbxproj
+++ b/HMSegmentedControlExample/HMSegmentedControlExample.xcodeproj/project.pbxproj
@@ -337,7 +337,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "HMSegmentedControlExample/HMSegmentedControlExample-Prefix.pch";
 				INFOPLIST_FILE = "HMSegmentedControlExample/HMSegmentedControlExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -349,7 +349,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "HMSegmentedControlExample/HMSegmentedControlExample-Prefix.pch";
 				INFOPLIST_FILE = "HMSegmentedControlExample/HMSegmentedControlExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A drop-in replacement for UISegmentedControl mimicking the style of the segmente
 # Features
 - Supports both text and images
 - Support horizontal scrolling
-- Font and all colors are customizable
+- Supports advanced title styling with text attributes for font, color, kerning, shadow, etc.
 - Supports selection indicator both on top and bottom
 - Supports blocks
-- Works with ARC and iOS >= 5
+- Works with ARC and iOS >= 7
 
 # Installation
 


### PR DESCRIPTION
Hey,

I've added support for advanced styling. HMSegmentedControl can now be adjusted for any custom design I can think of. In my case I needed kerning but stuff like shadows and other text attributes are now customisable.

I've dropped support for iOS 6 and below for the sake of simplicity: I would introduce a significant flaw by leaving the code for compatibility with the macros anyway — one would get the old behaviour on iOS 7+ if their app supported iOS 6 and below.