### PR TITLE
Segment alignment feature

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -28,6 +28,11 @@ typedef enum {
     HMSegmentedControlSegmentWidthStyleDynamic, // Segment width will only be as big as the text width (including inset)
 } HMSegmentedControlSegmentWidthStyle;
 
+typedef enum {
+    HMSegmentedControlSegmentAlignmentEdge, // Segments align to the edges of the view
+    HMSegmentedControlSegmentAlignmentCenter, // Selected segments are always centered in the view
+} HMSegmentedControlSegmentAlignment;
+
 enum {
     HMSegmentedControlNoSegment = -1   // Segment index for no selected segment
 };
@@ -113,6 +118,14 @@ typedef enum {
  Default is `HMSegmentedControlSegmentWidthStyleFixed`
  */
 @property (nonatomic, assign) HMSegmentedControlSegmentWidthStyle segmentWidthStyle;
+
+/*
+ Specifies the alignment of segments.
+ 
+ Default is `HMSegmentedControlSegmentAlignmentEdge`
+ */
+@property (nonatomic, assign) HMSegmentedControlSegmentAlignment segmentAlignment;
+
 
 /*
  Specifies the location of the selection indicator.

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -566,6 +566,24 @@
 
     self.scrollView.scrollEnabled = self.isUserDraggable;
     self.scrollView.contentSize = CGSizeMake([self totalSegmentedControlWidth], self.frame.size.height);
+    
+    // Set initial segments alignment and position
+    switch (self.segmentAlignment) {
+        case HMSegmentedControlSegmentAlignmentCenter: {
+            self.scrollView.contentInset = UIEdgeInsetsMake(0,
+                                                            self.scrollView.bounds.size.width / 2.0f - [self widthOfSegmentWithIndex:0] / 2.0f,
+                                                            0,
+                                                            self.scrollView.bounds.size.width / 2.0f - [self widthOfSegmentWithIndex:[self sectionCount] - 1] / 2.0f);
+            
+            break;
+        }
+            
+        case HMSegmentedControlSegmentAlignmentEdge:
+        default:
+            break;
+    }
+    
+    [self scrollToSelectedSegmentIndexAnimated:NO];
 }
 
 - (NSUInteger)sectionCount {
@@ -642,8 +660,17 @@
 }
 
 - (void)scrollToSelectedSegmentIndex {
+    [self scrollToSelectedSegmentIndexAnimated:YES];
+}
+
+- (void)scrollToSelectedSegmentIndexAnimated:(BOOL)animated {
+    if (self.selectedSegmentIndex == HMSegmentedControlNoSegment) {
+        return;
+    }
+    
     CGRect rectForSelectedIndex;
     CGFloat selectedSegmentOffset = 0;
+    
     if (self.segmentWidthStyle == HMSegmentedControlSegmentWidthStyleFixed) {
         rectForSelectedIndex = CGRectMake(self.segmentWidth * self.selectedSegmentIndex,
                                           0,
@@ -669,11 +696,36 @@
         selectedSegmentOffset = (CGRectGetWidth(self.frame) / 2) - ([[self.segmentWidthsArray objectAtIndex:self.selectedSegmentIndex] floatValue] / 2);
     }
     
-    
     CGRect rectToScrollTo = rectForSelectedIndex;
     rectToScrollTo.origin.x -= selectedSegmentOffset;
     rectToScrollTo.size.width += selectedSegmentOffset * 2;
-    [self.scrollView scrollRectToVisible:rectToScrollTo animated:YES];
+    
+    // Scroll to segment and apply segment alignment
+    switch (self.segmentAlignment) {
+        case HMSegmentedControlSegmentAlignmentCenter: {
+            CGPoint contentOffset = self.scrollView.contentOffset;
+            contentOffset.x = rectToScrollTo.origin.x;
+            
+            [self.scrollView setContentOffset:contentOffset animated:animated];
+            
+            break;
+        }
+            
+        case HMSegmentedControlSegmentAlignmentEdge:
+        default:
+            [self.scrollView scrollRectToVisible:rectToScrollTo animated:animated];
+            
+            break;
+    }
+}
+
+- (CGFloat)widthOfSegmentWithIndex:(NSInteger)index
+{
+    return self.segmentWidthsArray
+            ? index < ([self.segmentWidthsArray count] - 1)
+                ? [self.segmentWidthsArray[index] floatValue]
+                : 0
+            : self.segmentWidth;
 }
 
 #pragma mark - Index change

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A drop-in replacement for UISegmentedControl mimicking the style of the segmente
 - Support horizontal scrolling
 - Font and all colors are customizable
 - Supports selection indicator both on top and bottom
+- Supports segment alignment to the edge and centering of selected segments
 - Supports blocks
 - Works with ARC and iOS >= 5
 


### PR DESCRIPTION
Hello,

I've added a new property 'segmentAlignment'.

Its default value is HMSegmentedControlSegmentAlignmentEdge that keeps default behaviour of UIScrollView of aligning subviews to the edges.

Value HMSegmentedControlSegmentAlignmentCenter changes behaviour, so all subviews, including first and last ones, would be centered in the underlying UIScrollView.