### PR TITLE
Make the scrollView property public

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -49,11 +49,15 @@ typedef enum {
 	HMSegmentedControlTypeTextImages
 } HMSegmentedControlType;
 
+@interface HMScrollView : UIScrollView
+@end
+
 @interface HMSegmentedControl : UIControl
 
 @property (nonatomic, strong) NSArray *sectionTitles;
 @property (nonatomic, strong) NSArray *sectionImages;
 @property (nonatomic, strong) NSArray *sectionSelectedImages;
+@property (nonatomic, strong) HMScrollView *scrollView;
 
 /**
  Provide a block to be executed when selected index is changed.

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -10,8 +10,6 @@
 #import <QuartzCore/QuartzCore.h>
 #import <math.h>
 
-@interface HMScrollView : UIScrollView
-@end
 
 @interface HMSegmentedControl ()
 
@@ -20,7 +18,6 @@
 @property (nonatomic, strong) CALayer *selectionIndicatorArrowLayer;
 @property (nonatomic, readwrite) CGFloat segmentWidth;
 @property (nonatomic, readwrite) NSArray *segmentWidthsArray;
-@property (nonatomic, strong) HMScrollView *scrollView;
 
 @end
 


### PR DESCRIPTION
I needed to make the `scrollView` public.  This is useful so you can set its delegate and observe `scrollViewDidScroll`, etc.  My use case was showing a 'more' arrow on the right side unless the content of the control is scrolled all the way to the end.

![screen shot 2015-04-13 at 3 38 22 pm](https://cloud.githubusercontent.com/assets/411908/7123976/d35882e0-e1f3-11e4-8bab-78848aaa6c6b.png)

Thanks for the great library :)