### PR TITLE
A new property to manually manage the inset or outset margins for the rectangle around the titles.

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -81,6 +81,11 @@ typedef enum {
  */
 @property (nonatomic, strong) NSDictionary *selectedTitleTextAttributes UI_APPEARANCE_SELECTOR;
 
+/*
+ The inset or outset margins for the rectangle around the titles.
+ */
+@property (nonatomic, readwrite) UIEdgeInsets titleEdgeInsets;
+
 /**
  Segmented control background color.
  

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -315,7 +315,7 @@
             rect = CGRectMake(ceilf(rect.origin.x), ceilf(rect.origin.y), ceilf(rect.size.width), ceilf(rect.size.height));
             
             CATextLayer *titleLayer = [CATextLayer layer];
-            titleLayer.frame = rect;
+            titleLayer.frame = UIEdgeInsetsInsetRect(rect, self.titleEdgeInsets);
             titleLayer.alignmentMode = kCAAlignmentCenter;
             titleLayer.truncationMode = kCATruncationEnd;
             titleLayer.string = [self attributedTitleAtIndex:idx];
@@ -413,7 +413,7 @@
             textRect = CGRectMake(ceilf(textRect.origin.x), ceilf(textRect.origin.y), ceilf(textRect.size.width), ceilf(textRect.size.height));
 
             CATextLayer *titleLayer = [CATextLayer layer];
-            titleLayer.frame = textRect;
+            titleLayer.frame = UIEdgeInsetsInsetRect(textRect, self.titleEdgeInsets);
             titleLayer.alignmentMode = kCAAlignmentCenter;
             titleLayer.string = [self attributedTitleAtIndex:idx];
             titleLayer.truncationMode = kCATruncationEnd;

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -158,7 +158,9 @@
     self.selectionIndicatorBoxLayer.opacity = self.selectionIndicatorBoxOpacity;
     self.selectionIndicatorBoxLayer.borderWidth = 1.0f;
     self.selectionIndicatorBoxOpacity = 0.2;
-    
+
+    self.titleEdgeInsets = UIEdgeInsetsZero;
+
     self.contentMode = UIViewContentModeRedraw;
 }
 


### PR DESCRIPTION
Unlike the **Helvetica**, some custom fonts don't perfectly fit the effective drawing rectangle for the item (segment) title; therefore it would be nice to have a way to adjust this rectangle from the outside. I propose to add a new property to manually manage the inset or outset margins for the rectangle around the titles; that would look like **UIButton**'s [titleEdgeInsets](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIButton_Class/#//apple_ref/occ/instp/UIButton/titleEdgeInsets). For greater details please refer to the attached commits.
