### PR TITLE
should call -[super initWithFrame:] in `initWithSectionTitles`

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -73,7 +73,7 @@
 }
 
 - (id)initWithSectionTitles:(NSArray *)sectiontitles {
-    self = [self initWithFrame:CGRectZero];
+    self = [super initWithFrame:CGRectZero];
     
     if (self) {
         [self commonInit];


### PR DESCRIPTION
When initialize `HMSegmentedControl` instance with `initWithSectionTitles:`, `commonInit` will be called twice, one in `initWithSectionTitles:`, one in `initWithFrame:`.
