### PR TITLE
Add customisation for adding cornerRadius to SegmentedControl.

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -166,6 +166,13 @@ typedef enum {
 @property (nonatomic, assign) CGFloat borderWidth;
 
 /**
+ Specifies the corener radius .
+ 
+ Default is `0.0f`
+ */
+@property (nonatomic, assign) CGFloat corenerRadius;
+
+/**
  Default is YES. Set to NO to deny scrolling by dragging the scrollView by the user.
  */
 @property(nonatomic, getter = isUserDraggable) BOOL userDraggable;

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -149,7 +149,8 @@
     _verticalDividerColor = [UIColor blackColor];
     self.borderColor = [UIColor blackColor];
     self.borderWidth = 1.0f;
-    
+    self.corenerRadius = 0.0f;
+	
     self.shouldAnimateUserSelection = YES;
     
     self.selectionIndicatorArrowLayer = [CALayer layer];
@@ -270,6 +271,7 @@
     
     self.selectionIndicatorBoxLayer.backgroundColor = self.selectionIndicatorColor.CGColor;
     self.selectionIndicatorBoxLayer.borderColor = self.selectionIndicatorColor.CGColor;
+	self.selectionIndicatorBoxLayer.cornerRadius = self.corenerRadius;
     
     // Remove all sublayers to avoid drawing images over existing ones
     self.scrollView.layer.sublayers = nil;


### PR DESCRIPTION
**Add customisation for adding cornerRadius to SegmentedControl using selectionIndicatorBoxLayer** 

Add cornerRadius property for optional customisation.  Corner Radius will add rounded corner to BoxLayers.

Usage as follows:

```
HMSegmentedControl *segmentedControl1 = [[HMSegmentedControl alloc] initWithSectionTitles:@[@"One", @"Two", @"Three", @"Four", @"Five", @"Six", @"Seven", @"Eight"]];
segmentedControl1.cornerRadius = 2.0f;
```
