### PR TITLE
Expose a function to call UIControlEventValueChanged

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -223,6 +223,7 @@ typedef enum {
 - (id)initWithSectionImages:(NSArray *)sectionImages sectionSelectedImages:(NSArray *)sectionSelectedImages;
 - (instancetype)initWithSectionImages:(NSArray *)sectionImages sectionSelectedImages:(NSArray *)sectionSelectedImages titlesForSections:(NSArray *)sectiontitles;
 - (void)setSelectedSegmentIndex:(NSUInteger)index animated:(BOOL)animated;
+- (void)setSelectedSegmentIndex:(NSUInteger)index animated:(BOOL)animated notify:(BOOL)notify;
 - (void)setIndexChangeBlock:(IndexChangeBlock)indexChangeBlock;
 - (void)setTitleFormatter:(HMTitleFormatterBlock)titleFormatter;
 

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -781,6 +781,9 @@
 }
 
 - (void)setSelectedSegmentIndex:(NSUInteger)index animated:(BOOL)animated notify:(BOOL)notify {
+    if (_selectedSegmentIndex == index && notify)
+        notify = NO;
+
     _selectedSegmentIndex = index;
     [self setNeedsDisplay];
     

--- a/HMSegmentedControlExample/HMSegmentedControlExample/ViewController.m
+++ b/HMSegmentedControlExample/HMSegmentedControlExample/ViewController.m
@@ -91,7 +91,9 @@
     self.segmentedControl4.selectionStyle = HMSegmentedControlSelectionStyleBox;
     self.segmentedControl4.selectionIndicatorLocation = HMSegmentedControlSelectionIndicatorLocationUp;
     self.segmentedControl4.tag = 3;
-    
+
+    [self.segmentedControl4 addTarget:self action:@selector(segmentChanged:) forControlEvents:UIControlEventValueChanged];
+
     __weak typeof(self) weakSelf = self;
     [self.segmentedControl4 setIndexChangeBlock:^(NSInteger index) {
         [weakSelf.scrollView scrollRectToVisible:CGRectMake(viewWidth * index, 0, viewWidth, 200) animated:YES];
@@ -143,13 +145,19 @@
 	NSLog(@"Selected index %ld", (long)segmentedControl.selectedSegmentIndex);
 }
 
+#pragma mark - Selector
+
+- (void)segmentChanged:(HMSegmentedControl*)segment {
+    NSLog(@"Segment changed: %ld", segment.selectedSegmentIndex);
+}
+
 #pragma mark - UIScrollViewDelegate
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
     CGFloat pageWidth = scrollView.frame.size.width;
     NSInteger page = scrollView.contentOffset.x / pageWidth;
     
-    [self.segmentedControl4 setSelectedSegmentIndex:page animated:YES];
+    [self.segmentedControl4 setSelectedSegmentIndex:page animated:YES notify:YES];
 }
 
 @end


### PR DESCRIPTION
Expose a function `- (void)setSelectedSegmentIndex:(NSUInteger)index animated:(BOOL)animated notify:(BOOL)notify`, which can let users to call on scroll or page change.
[Page Change Issue](https://github.com/hons82/THSegmentedPager/issues/24) for reference.
This PR is a fix for [Issue 181](https://github.com/HeshamMegid/HMSegmentedControl/issues/181)
