### PR TITLE
Allows for edge insets on the text lablels

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -207,6 +207,18 @@ typedef enum {
  */
 @property (nonatomic, readwrite) UIEdgeInsets selectionIndicatorEdgeInsets;
 
+
+/**
+ Edge insets for the text labels.
+ 
+ Defaults are top: 0.0f
+ left: 0.0f
+ bottom: 0.0f
+ right: 0.0f
+ */
+@property (nonatomic, readwrite) UIEdgeInsets textLabelInsets;
+
+
 /**
  Inset left and right edges of segments.
  

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -315,6 +315,7 @@
             
             // Fix rect position/size to avoid blurry labels
             rect = CGRectMake(ceilf(rect.origin.x), ceilf(rect.origin.y), ceilf(rect.size.width), ceilf(rect.size.height));
+            rect = UIEdgeInsetsInsetRect(rect, self.textLabelInsets);
             
             CATextLayer *titleLayer = [CATextLayer layer];
             titleLayer.frame = rect;


### PR DESCRIPTION
I ran into a situation where I really needed to slightly adjust the position of the text labels. This commit adds a `textLabelInsets` property which allows users to adjust the label position within the segment. 
