### PR TITLE
Use 'super initWithFrame' instead of 'self initWithFrame'.

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -73,7 +73,7 @@
 }
 
 - (id)initWithSectionTitles:(NSArray *)sectiontitles {
-    self = [self initWithFrame:CGRectZero];
+    self = [super initWithFrame:CGRectZero];
     
     if (self) {
         [self commonInit];


### PR DESCRIPTION
The same methods for all init calls.
