### PR TITLE
Fix bug crash when set sectionTitles is an empty array

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -217,6 +217,10 @@
 #pragma mark - Drawing
 
 - (CGSize)measureTitleAtIndex:(NSUInteger)index {
+    if (index >= self.sectionTitles.count) {
+        return CGSizeZero;
+    }
+    
     id title = self.sectionTitles[index];
     CGSize size = CGSizeZero;
     BOOL selected = (index == self.selectedSegmentIndex) ? YES : NO;


### PR DESCRIPTION
 - Reproduce: Set sectionTitles/initWithSectionTitles with an empty array param. 
- Reason: Out of bound, access element at 0, while array has no item
- Solution: Check index out of bound before get title from array
