### PR TITLE
Enable setting of horizontal alignment and fix for arrow positions for dynamic segment widths

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -49,6 +49,12 @@ typedef NS_ENUM(NSInteger, HMSegmentedControlType) {
 	HMSegmentedControlTypeTextImages
 };
 
+typedef NS_OPTIONS(NSInteger, HMSegmentedControlAlignment) {
+    HMSegmentedControlAlignmentLeft = 0,
+    HMSegmentedControlAlignmentCenter = (1 << 0),
+    HMSegmentedControlAlignmentRight = (1 << 1)
+};
+
 @interface HMSegmentedControl : UIControl
 
 @property (nonatomic, strong) NSArray *sectionTitles;
@@ -220,6 +226,12 @@ typedef NS_ENUM(NSInteger, HMSegmentedControlType) {
  Default is YES. Set to NO to disable animation during user selection.
  */
 @property (nonatomic) BOOL shouldAnimateUserSelection;
+
+
+/**
+ Default is HMSegmentedControlAlignmentLeft. This property is only effective, if segmentWidthStyle is set to HMSegmentedControlSegmentWidthStyleDynamic.
+ */
+@property (nonatomic, assign) HMSegmentedControlAlignment horizontalAlignment;
 
 - (id)initWithSectionTitles:(NSArray *)sectiontitles;
 - (id)initWithSectionImages:(NSArray *)sectionImages sectionSelectedImages:(NSArray *)sectionSelectedImages;

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -561,8 +561,16 @@
 	}
     
     if (self.selectionStyle == HMSegmentedControlSelectionStyleArrow) {
-        CGFloat widthToEndOfSelectedSegment = (self.segmentWidth * self.selectedSegmentIndex) + self.segmentWidth;
-        CGFloat widthToStartOfSelectedIndex = (self.segmentWidth * self.selectedSegmentIndex);
+        CGFloat widthToStartOfSelectedIndex = 0.0, widthToEndOfSelectedSegment = 0.0;
+        if (self.segmentWidthStyle == HMSegmentedControlSegmentWidthStyleDynamic) {
+            for (int idx = 0; idx < self.selectedSegmentIndex; ++idx) {
+                widthToStartOfSelectedIndex += [[self.segmentWidthsArray objectAtIndex:idx] floatValue];
+            }
+            widthToEndOfSelectedSegment = widthToStartOfSelectedIndex + [[self.segmentWidthsArray objectAtIndex:self.selectedSegmentIndex] floatValue];
+        } else {
+            widthToEndOfSelectedSegment = (self.segmentWidth * self.selectedSegmentIndex) + self.segmentWidth;
+            widthToStartOfSelectedIndex = (self.segmentWidth * self.selectedSegmentIndex);
+        }
         
         CGFloat x = widthToStartOfSelectedIndex + ((widthToEndOfSelectedSegment - widthToStartOfSelectedIndex) / 2) - (self.selectionIndicatorHeight/2);
         return CGRectMake(x - (self.selectionIndicatorHeight / 2), indicatorYOffset, self.selectionIndicatorHeight * 2, self.selectionIndicatorHeight);

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -693,6 +693,12 @@
     
     if (self.sectionTitles || self.sectionImages) {
         [self updateSegmentsRects];
+
+        if (self.segmentWidthStyle == HMSegmentedControlSegmentWidthStyleDynamic) {
+            // Now that the segments are updated and segmentWidthsArray is no longer nil,
+            // scroll to the right segment (again).
+            [self scrollToSelectedSegmentIndex:NO];
+        }
     }
 }
 


### PR DESCRIPTION
When both HMSegmentedControlSelectionStyleArrow and HMSegmentedControlSegmentWidthStyleDynamic are set, arrows were still positioned in relation to fixed-width segments.

![hmsegmentedcontrol_bug](https://cloud.githubusercontent.com/assets/2779613/19276573/17cbcdc8-8fd7-11e6-97f0-1bce55d1ab1b.jpg)
