### PR TITLE
Made public API more swift-friendly

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -51,9 +51,9 @@ typedef NS_ENUM(NSInteger, HMSegmentedControlType) {
 
 @interface HMSegmentedControl : UIControl
 
-@property (nonatomic, strong) NSArray *sectionTitles;
-@property (nonatomic, strong) NSArray *sectionImages;
-@property (nonatomic, strong) NSArray *sectionSelectedImages;
+@property (nonatomic, strong) NSArray<NSString *> *sectionTitles;
+@property (nonatomic, strong) NSArray<UIImage *> *sectionImages;
+@property (nonatomic, strong) NSArray<UIImage *> *sectionSelectedImages;
 
 /**
  Provide a block to be executed when selected index is changed.
@@ -72,14 +72,14 @@ typedef NS_ENUM(NSInteger, HMSegmentedControlType) {
 /**
  Text attributes to apply to item title text.
  */
-@property (nonatomic, strong) NSDictionary *titleTextAttributes UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *titleTextAttributes UI_APPEARANCE_SELECTOR;
 
 /*
  Text attributes to apply to selected item title text.
  
  Attributes not set in this dictionary are inherited from `titleTextAttributes`.
  */
-@property (nonatomic, strong) NSDictionary *selectedTitleTextAttributes UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *selectedTitleTextAttributes UI_APPEARANCE_SELECTOR;
 
 /**
  Segmented control background color.
@@ -228,9 +228,9 @@ typedef NS_ENUM(NSInteger, HMSegmentedControlType) {
  */
 @property (nonatomic) BOOL shouldAnimateUserSelection;
 
-- (id)initWithSectionTitles:(NSArray *)sectiontitles;
-- (id)initWithSectionImages:(NSArray *)sectionImages sectionSelectedImages:(NSArray *)sectionSelectedImages;
-- (instancetype)initWithSectionImages:(NSArray *)sectionImages sectionSelectedImages:(NSArray *)sectionSelectedImages titlesForSections:(NSArray *)sectiontitles;
+- (instancetype _Nonnull)initWithSectionTitles:(NSArray<NSString *> * _Nonnull )sectiontitles;
+- (instancetype _Nonnull)initWithSectionImages:(NSArray<UIImage *> * _Nonnull )sectionImages sectionSelectedImages:(NSArray<UIImage *> * _Nonnull )sectionSelectedImages;
+- (instancetype _Nonnull)initWithSectionImages:(NSArray<UIImage *> * _Nonnull )sectionImages sectionSelectedImages:(NSArray<UIImage *> * _Nonnull )sectionSelectedImages titlesForSections:(NSArray<NSString *> * _Nonnull )sectiontitles;
 - (void)setSelectedSegmentIndex:(NSUInteger)index animated:(BOOL)animated;
 - (void)setIndexChangeBlock:(IndexChangeBlock)indexChangeBlock;
 - (void)setTitleFormatter:(HMTitleFormatterBlock)titleFormatter;

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -72,7 +72,7 @@
     return self;
 }
 
-- (id)initWithSectionTitles:(NSArray *)sectiontitles {
+- (instancetype)initWithSectionTitles:(NSArray<NSString *> * _Nonnull )sectiontitles {
     self = [super initWithFrame:CGRectZero];
     
     if (self) {
@@ -84,7 +84,7 @@
     return self;
 }
 
-- (id)initWithSectionImages:(NSArray*)sectionImages sectionSelectedImages:(NSArray*)sectionSelectedImages {
+- (instancetype)initWithSectionImages:(NSArray<UIImage *> * _Nonnull )sectionImages sectionSelectedImages:(NSArray<UIImage *> * _Nonnull )sectionSelectedImages {
     self = [super initWithFrame:CGRectZero];
     
     if (self) {
@@ -97,7 +97,7 @@
     return self;
 }
 
-- (instancetype)initWithSectionImages:(NSArray *)sectionImages sectionSelectedImages:(NSArray *)sectionSelectedImages titlesForSections:(NSArray *)sectiontitles {
+- (instancetype)initWithSectionImages:(NSArray<UIImage *> * _Nonnull )sectionImages sectionSelectedImages:(NSArray<UIImage *> * _Nonnull )sectionSelectedImages titlesForSections:(NSArray<NSString *> * _Nonnull )sectiontitles {
 	self = [super initWithFrame:CGRectZero];
     
     if (self) {
@@ -874,13 +874,13 @@
 
 #pragma mark - Styling Support
 
-- (NSDictionary *)resultingTitleTextAttributes {
-    NSDictionary *defaults = @{
+- (NSDictionary<NSString *, id> *)resultingTitleTextAttributes {
+    NSDictionary<NSString *, id> *defaults = @{
         NSFontAttributeName : [UIFont systemFontOfSize:19.0f],
         NSForegroundColorAttributeName : [UIColor blackColor],
     };
     
-    NSMutableDictionary *resultingAttrs = [NSMutableDictionary dictionaryWithDictionary:defaults];
+    NSMutableDictionary<NSString *, id> *resultingAttrs = [NSMutableDictionary dictionaryWithDictionary:defaults];
     
     if (self.titleTextAttributes) {
         [resultingAttrs addEntriesFromDictionary:self.titleTextAttributes];
@@ -889,8 +889,8 @@
     return [resultingAttrs copy];
 }
 
-- (NSDictionary *)resultingSelectedTitleTextAttributes {
-    NSMutableDictionary *resultingAttrs = [NSMutableDictionary dictionaryWithDictionary:[self resultingTitleTextAttributes]];
+- (NSDictionary<NSString *, id> *)resultingSelectedTitleTextAttributes {
+    NSMutableDictionary<NSString *, id> *resultingAttrs = [NSMutableDictionary dictionaryWithDictionary:[self resultingTitleTextAttributes]];
     
     if (self.selectedTitleTextAttributes) {
         [resultingAttrs addEntriesFromDictionary:self.selectedTitleTextAttributes];


### PR DESCRIPTION
Hi,

I'm using this ui control from in a swift project and I noticed that its API is less than elegant in a few ways.

To resolve that issue, I added generic types and nullability annotations in some parts of the SegmentedControl class.

Note: Because I added nullability annotations, XCode now gives warnings saying that some fields are missing annotations. If this PR is approved, I'll make another one that fixes those.

If you have any questions let me know.

Thank you for this awesome project !