### PR TITLE
Add support to segments to notify when their touched, regardless if changed

### DIFF
--- a/HMSegmentedControl.podspec
+++ b/HMSegmentedControl.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "HMSegmentedControl"
-  s.version      = "1.5.4"
+  s.version      = "1.5.5"
   s.summary      = "A drop-in replacement for UISegmentedControl mimicking the style of the one in Google Currents and various other Google products."
   s.homepage     = "https://github.com/HeshamMegid/HMSegmentedControl"
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }

--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -11,6 +11,7 @@
 @class HMSegmentedControl;
 
 typedef void (^IndexChangeBlock)(NSInteger index);
+typedef void (^IndexSelectBlock)(NSInteger index);
 typedef NSAttributedString *(^HMTitleFormatterBlock)(HMSegmentedControl *segmentedControl, NSString *title, NSUInteger index, BOOL selected);
 
 typedef NS_ENUM(NSInteger, HMSegmentedControlSelectionStyle) {
@@ -69,6 +70,11 @@ typedef NS_ENUM(NSInteger, HMSegmentedControlImagePosition) {
  Alternativly, you could use `addTarget:action:forControlEvents:`
  */
 @property (nonatomic, copy) IndexChangeBlock indexChangeBlock;
+
+/**
+ Provide a block to be executed when a segment is selected, regardless if it was changed.
+ */
+@property (nonatomic, copy) IndexSelectBlock indexSelectBlock;
 
 /**
  Used to apply custom text styling to titles when set.
@@ -257,6 +263,7 @@ typedef NS_ENUM(NSInteger, HMSegmentedControlImagePosition) {
 - (instancetype)initWithSectionImages:(NSArray<UIImage *> *)sectionImages sectionSelectedImages:(NSArray<UIImage *> *)sectionSelectedImages titlesForSections:(NSArray<NSString *> *)sectiontitles;
 - (void)setSelectedSegmentIndex:(NSUInteger)index animated:(BOOL)animated;
 - (void)setIndexChangeBlock:(IndexChangeBlock)indexChangeBlock;
+- (void)setIndexSelectBlock:(IndexSelectBlock)indexSelectBlock;
 - (void)setTitleFormatter:(HMTitleFormatterBlock)titleFormatter;
 
 @end

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -791,6 +791,9 @@
             if (self.isTouchEnabled)
                 [self setSelectedSegmentIndex:segment animated:self.shouldAnimateUserSelection notify:YES];
         }
+
+        if (self.indexSelectBlock)
+            self.indexSelectBlock(segment);
     }
 }
 


### PR DESCRIPTION
Thanks for all the great work! I've taken the liberty to add support to segments to notify handler when their touched, regardless if changed (as with indexChangeBlock). This is useful if you want to trigger an event regardless if the value has changed, which might for example display help, update status, or act as a button. Below is an example transforming the handler in a delegate which in turn, may do additional functionality.

```swift
    menuControl.indexSelectBlock = { i -> Void in
             menuDelegate?.menu(self, didSelectItemAtIndex: i)
    }
```