### PR TITLE
Add very basic accessibility support

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -20,6 +20,7 @@
 @property (nonatomic, strong) CALayer *selectionIndicatorArrowLayer;
 @property (nonatomic, readwrite) CGFloat segmentWidth;
 @property (nonatomic, readwrite) NSArray<NSNumber *> *segmentWidthsArray;
+@property (nonatomic, readwrite) NSArray<UIAccessibilityElement *> *accessibleElements;
 @property (nonatomic, strong) HMScrollView *scrollView;
 
 @end
@@ -967,6 +968,52 @@
     }
     
     return [resultingAttrs copy];
+}
+
+#pragma mark - Accessibility
+
+- (NSArray *)accessibleElements
+{
+    if (_accessibleElements) {
+        return _accessibleElements;
+    }
+
+    NSMutableArray<UIAccessibilityElement *> *elements = [NSMutableArray array];
+    for (CALayer *layer in self.scrollView.layer.sublayers) {
+        if ([layer isKindOfClass:[CATextLayer class]]) {
+            CATextLayer *textLayer = (CATextLayer *)layer;
+
+            UIAccessibilityElement *element = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
+            element.accessibilityFrame = UIAccessibilityConvertFrameToScreenCoordinates(textLayer.frame, self.scrollView);
+            element.accessibilityLabel = textLayer.string;
+            element.accessibilityTraits = UIAccessibilityTraitButton;
+            [elements addObject:element];
+        }
+    }
+
+    _accessibleElements = elements;
+
+    return elements;
+}
+
+- (BOOL)isAccessibilityElement
+{
+    return NO;
+}
+
+- (NSInteger)accessibilityElementCount
+{
+    return self.accessibleElements.count;
+}
+
+- (id)accessibilityElementAtIndex:(NSInteger)index
+{
+    return self.accessibleElements[index];
+}
+
+- (NSInteger)indexOfAccessibilityElement:(id)element
+{
+    return [self.accessibleElements indexOfObject:element];
 }
 
 @end


### PR DESCRIPTION
- this adds the bare minimum of accessibility support so that
  VoiceOver can "see" the elements on screen
- the frames for the elements are only around the actual text, for
  proper support they should match the larger frame that a user
  actually taps on
![img_0025](https://user-images.githubusercontent.com/1180883/44686623-d0948280-aa1c-11e8-86c4-d9d61f5d72cd.jpg)

c.f. https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/iPhoneAccessibility/Making_Application_Accessible/Making_Application_Accessible.html#//apple_ref/doc/uid/TP40008785-CH102-SW25